### PR TITLE
Update atlas-cluster.tf

### DIFF
--- a/atlas-cluster.tf
+++ b/atlas-cluster.tf
@@ -13,7 +13,8 @@ resource "mongodbatlas_cluster" "cluster-atlas" {
   name                         = "cluster-atlas"
   num_shards                   = 1
   replication_factor           = 3
-  backup_enabled               = true
+  backup_enabled               = false
+  provider_backup_enabled      = true
   auto_scaling_disk_gb_enabled = true
   mongo_db_major_version       = "4.0"
 


### PR DESCRIPTION
Continuous is not longer supported  on AWS for new clusters so changing the variable for backup to CPS.   Our updated doc on this will come out with the next version but wanted to make sure your excellent example was correct.